### PR TITLE
Add debug mode with hitbox visualization for game entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ A modern Vue 3 reinterpretation of the classic arcade game Pang, featuring polis
 - Power-ups store and upgrade system
 - Modular, maintainable codebase with reusable UI components
 - Responsive design and global styles
+- **Debug Mode:** Visualize collision hitboxes for bubbles, player, and projectiles (see below)
+
+## Debug Mode
+
+You can enable a debug mode during gameplay to visualize collision areas:
+
+- **How to enable:** Press the <kbd>D</kbd> key while playing to toggle debug mode on or off.
+- **What it does:**
+  - Draws red outlines around all bubble hitboxes
+  - Draws blue outlines around the player hitbox (body and head)
+  - Draws green outlines around projectile hitboxes
+- Use this to test and debug collision detection, especially for edge cases or new features.
 
 ## Game Modes
 

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -84,6 +84,13 @@ window.floatingTexts = floatingTexts.value;
 // Input system
 const { keysPressed } = useInput();
 
+// Debug mode
+const debugMode = ref(false);
+// Toggle debug mode with 'D' key
+window.addEventListener('keydown', (e) => {
+  if (e.code === 'KeyD') debugMode.value = !debugMode.value;
+});
+
 // Initialize game systems
 const { startGameLoop, stopGameLoop } = useGameLoop();
 const { player, updatePlayer, drawPlayer, resetPlayer } = usePlayer(gameWidth, gameHeight);
@@ -162,9 +169,9 @@ const updateGame = () => {
   checkCollisions(comboMultiplier.value);
 
   // Drawing
-  drawBubbles(ctx);
-  drawProjectiles(ctx);
-  drawPlayer(ctx);
+  drawBubbles(ctx, debugMode.value);
+  drawProjectiles(ctx, debugMode.value);
+  drawPlayer(ctx, debugMode.value);
   drawFloatingTexts(ctx);
 
   // Check for game over

--- a/src/core/entities/bubbles.js
+++ b/src/core/entities/bubbles.js
@@ -113,13 +113,24 @@ export function useBubbles(gameWidth, gameHeight) {
     }
   };
   
-  const drawBubbles = (ctx) => {
+  const drawBubbles = (ctx, debugMode = false) => {
     bubbles.value.forEach(bubble => {
       ctx.beginPath();
       ctx.arc(bubble.x, bubble.y, bubble.radius, 0, Math.PI * 2);
       ctx.fillStyle = bubble.color;
       ctx.fill();
-      
+
+      // Debug: draw hitbox
+      if (debugMode) {
+        ctx.save();
+        ctx.strokeStyle = 'red';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(bubble.x, bubble.y, bubble.radius, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+      }
+
       // Add shine effect
       ctx.beginPath();
       ctx.arc(

--- a/src/core/entities/player.js
+++ b/src/core/entities/player.js
@@ -29,7 +29,7 @@ export function usePlayer(gameWidth, gameHeight) {
     }
   };
   
-  const drawPlayer = (ctx) => {
+  const drawPlayer = (ctx, debugMode = false) => {
     ctx.fillStyle = player.value.color;
     
     // Draw player body
@@ -50,6 +50,31 @@ export function usePlayer(gameWidth, gameHeight) {
       Math.PI * 2
     );
     ctx.fill();
+
+    // Debug: draw hitboxes
+    if (debugMode) {
+      ctx.save();
+      ctx.strokeStyle = 'blue';
+      ctx.lineWidth = 2;
+      // Rectangle hitbox
+      ctx.strokeRect(
+        player.value.x,
+        player.value.y,
+        player.value.width,
+        player.value.height
+      );
+      // Head hitbox
+      ctx.beginPath();
+      ctx.arc(
+        player.value.x + player.value.width / 2,
+        player.value.y,
+        player.value.width / 2.5,
+        0,
+        Math.PI * 2
+      );
+      ctx.stroke();
+      ctx.restore();
+    }
   };
   
   return {

--- a/src/core/systems/projectiles.js
+++ b/src/core/systems/projectiles.js
@@ -45,7 +45,7 @@ export function useProjectiles() {
     });
   };
   
-  const drawProjectiles = (ctx) => {
+  const drawProjectiles = (ctx, debugMode = false) => {
     projectiles.value.forEach(projectile => {
       if (projectile.active) {
         ctx.fillStyle = projectile.color;
@@ -55,6 +55,19 @@ export function useProjectiles() {
           projectile.width,
           projectile.height
         );
+        // Debug: draw hitbox
+        if (debugMode) {
+          ctx.save();
+          ctx.strokeStyle = 'green';
+          ctx.lineWidth = 2;
+          ctx.strokeRect(
+            projectile.x,
+            projectile.y,
+            projectile.width,
+            projectile.height
+          );
+          ctx.restore();
+        }
       }
     });
   };


### PR DESCRIPTION
This pull request introduces a new debug mode to the game, allowing developers to visualize collision hitboxes for bubbles, the player, and projectiles. The debug mode can be toggled during gameplay using the <kbd>D</kbd> key. Changes span multiple files to integrate this feature into the game's rendering system.

### Debug Mode Implementation:

* **README Update**: Added a description of the debug mode, including instructions for enabling it and details on its functionality.
* **Game Logic**: Introduced a `debugMode` reactive variable in `Game.vue` to track the debug mode state, and added an event listener to toggle the mode using the <kbd>D</kbd> key. Updated the `updateGame` function to pass `debugMode` to rendering functions. [[1]](diffhunk://#diff-c484d24b6e073a86bb9bf083158dcf671531573dae0eb506adb886f1ea1a3680R87-R93) [[2]](diffhunk://#diff-c484d24b6e073a86bb9bf083158dcf671531573dae0eb506adb886f1ea1a3680L165-R174)

### Rendering System Updates:

* **Bubbles**: Modified the `drawBubbles` function in `bubbles.js` to draw red outlines around bubble hitboxes when debug mode is active.
* **Player**: Updated the `drawPlayer` function in `player.js` to visualize hitboxes for the player's body (blue rectangle) and head (blue circle) when debug mode is enabled. [[1]](diffhunk://#diff-066431f81c1cc0b666b0180b604f79ed60ba7bcfac40afc49aa26c72b3853854L32-R32) [[2]](diffhunk://#diff-066431f81c1cc0b666b0180b604f79ed60ba7bcfac40afc49aa26c72b3853854R53-R77)
* **Projectiles**: Enhanced the `drawProjectiles` function in `projectiles.js` to display green hitbox rectangles for active projectiles during debug mode. [[1]](diffhunk://#diff-045fa081c8db2584af3a33bd421dab358e0996fd3eb1107eced714c5b17ed45dL48-R48) [[2]](diffhunk://#diff-045fa081c8db2584af3a33bd421dab358e0996fd3eb1107eced714c5b17ed45dR58-R70)